### PR TITLE
Introduce evacuateOnReboot, inhibit reboot till all VMs been evicted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Image URL to use all building/pushing image targets
-IMG ?= keppel.eu-de-1.cloud.sap/ccloud/kvm-node-agent:latest
+TAG ?= latest
+IMG ?= keppel.eu-de-1.cloud.sap/ccloud/kvm-node-agent:$(TAG)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.30.0
 

--- a/api/v1alpha1/hypervisor_types.go
+++ b/api/v1alpha1/hypervisor_types.go
@@ -35,6 +35,10 @@ type HypervisorSpec struct {
 	// +kubebuilder:default:=false
 	// Reboot request an reboot after successful installation of an upgrade.
 	Reboot bool `json:"reboot"`
+
+	// +kubebuilder:default:=true
+	// EvacuateOnReboot request an evacuation of all instances before reboot.
+	EvacuateOnReboot bool `json:"evacuateOnReboot"`
 }
 
 type Instance struct {

--- a/charts/kvm-node-agent/crds/hypervisor-crd.yaml
+++ b/charts/kvm-node-agent/crds/hypervisor-crd.yaml
@@ -48,6 +48,11 @@ spec:
           spec:
             description: HypervisorSpec defines the desired state of Hypervisor
             properties:
+              evacuateOnReboot:
+                default: true
+                description: EvacuateOnReboot request an evacuation of all instances
+                  before reboot.
+                type: boolean
               reboot:
                 default: false
                 description: Reboot request an reboot after successful installation
@@ -58,6 +63,7 @@ spec:
                   system version.
                 type: string
             required:
+            - evacuateOnReboot
             - reboot
             type: object
           status:

--- a/charts/kvm-node-agent/templates/manager-rbac.yaml
+++ b/charts/kvm-node-agent/templates/manager-rbac.yaml
@@ -22,6 +22,13 @@ rules:
 - apiGroups:
   - kvm.cloud.sap
   resources:
+  - evictions
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - kvm.cloud.sap
+  resources:
   - hypervisors
   verbs:
   - create

--- a/config/crd/bases/kvm.cloud.sap_hypervisors.yaml
+++ b/config/crd/bases/kvm.cloud.sap_hypervisors.yaml
@@ -49,6 +49,11 @@ spec:
           spec:
             description: HypervisorSpec defines the desired state of Hypervisor
             properties:
+              evacuateOnReboot:
+                default: true
+                description: EvacuateOnReboot request an evacuation of all instances
+                  before reboot.
+                type: boolean
               reboot:
                 default: false
                 description: Reboot request an reboot after successful installation
@@ -59,6 +64,7 @@ spec:
                   system version.
                 type: string
             required:
+            - evacuateOnReboot
             - reboot
             type: object
           status:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: kvm-node-agent-system
+namespace: monsoon3
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,6 +21,13 @@ rules:
 - apiGroups:
   - kvm.cloud.sap
   resources:
+  - evictions
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - kvm.cloud.sap
+  resources:
   - hypervisors
   verbs:
   - create

--- a/internal/emulator/libvirt.go
+++ b/internal/emulator/libvirt.go
@@ -14,18 +14,21 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package libvirt
+
+package emulator
 
 import (
 	"context"
 
-	"github.com/cobaltcode-dev/kvm-node-agent/api/v1alpha1"
 	logger "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/cobaltcode-dev/kvm-node-agent/api/v1alpha1"
+	"github.com/cobaltcode-dev/kvm-node-agent/internal/libvirt"
 )
 
-func NewLibVirtEmulator(ctx context.Context) *InterfaceMock {
+func NewLibVirtEmulator(ctx context.Context) *libvirt.InterfaceMock {
 	log := logger.FromContext(ctx, "controller", "libvirt-emulator")
-	mockedInterface := &InterfaceMock{
+	mockedInterface := &libvirt.InterfaceMock{
 		CloseFunc: func() error {
 			log.Info("CloseFunc called")
 			return nil

--- a/internal/emulator/systemd.go
+++ b/internal/emulator/systemd.go
@@ -14,19 +14,22 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package systemd
+
+package emulator
 
 import (
 	"context"
 
-	"github.com/cobaltcode-dev/kvm-node-agent/api/v1alpha1"
 	"github.com/coreos/go-systemd/v22/dbus"
 	logger "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/cobaltcode-dev/kvm-node-agent/api/v1alpha1"
+	"github.com/cobaltcode-dev/kvm-node-agent/internal/systemd"
 )
 
-func NewSystemdEmulator(ctx context.Context) *InterfaceMock {
+func NewSystemdEmulator(ctx context.Context) *systemd.InterfaceMock {
 	log := logger.FromContext(ctx, "controller", "systemd-emulator")
-	mockedInterface := &InterfaceMock{
+	mockedInterface := &systemd.InterfaceMock{
 		CloseFunc: func() {
 			log.Info("CloseFunc called")
 		},
@@ -49,6 +52,14 @@ func NewSystemdEmulator(ctx context.Context) *InterfaceMock {
 		StartUnitFunc: func(ctx context.Context, unit string) (int, error) {
 			log.Info("GetUnitByNameFunc called")
 			return 0, nil
+		},
+		EnableShutdownInhibitFunc: func(ctx context.Context, cb func(ctx context.Context) error) error {
+			log.Info("GetUnitByNameFunc called")
+			return nil
+		},
+		DisableShutdownInhibitFunc: func() error {
+			log.Info("GetUnitByNameFunc called")
+			return nil
 		},
 	}
 	return mockedInterface

--- a/internal/evacuation/eviction.go
+++ b/internal/evacuation/eviction.go
@@ -1,0 +1,88 @@
+/*
+SPDX-FileCopyrightText: Copyright 2024 SAP SE or an SAP affiliate company and cobaltcore-dev contributors
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, LibVirtVersion 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package evacuation
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logger "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/cobaltcode-dev/kvm-node-agent/internal/sys"
+)
+
+type EvictionController struct {
+	client.Client
+}
+
+// EvictCurrentHost callback is allowed to block. It is called when the hypervisor is about to be rebooted.
+// It should migrate all VMs away from the current host.
+// It is able to block up to InhibitDelayMaxSec seconds to evict virtual machines.
+// see `systemd-analyze cat-config systemd/logind.conf` for the current setting.
+func (e *EvictionController) EvictCurrentHost(ctx context.Context) error {
+	log := logger.FromContext(ctx)
+
+	u := &unstructured.Unstructured{}
+	u.SetUnstructuredContent(map[string]interface{}{
+		"spec": map[string]interface{}{
+			"hypervisor": sys.Hostname,
+			"reason":     "kvm-node-agent: emergency evacuation due to host reboot",
+		},
+	})
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "kvm.cloud.sap",
+		Kind:    "Eviction",
+		Version: "v1",
+	})
+	u.SetName(sys.Hostname)
+	// todo: namespace? cluster-wide?
+	u.SetNamespace("monsoon3")
+
+	// ... create the eviction custom resource
+	if err := e.Create(ctx, u); client.IgnoreAlreadyExists(err) != nil {
+		return err
+	}
+
+	log.Info("Eviction custom resource created for current host")
+
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		if err := e.Get(ctx, client.ObjectKeyFromObject(u), u); err != nil {
+			return err
+		}
+
+		state, _, err := unstructured.NestedString(u.Object, "status", "evictionState")
+		if err != nil {
+			return err
+		}
+
+		log.WithValues("node", u.GetName(), "state", state).Info("Eviction progress")
+
+		if state == "Succeeded" {
+			return nil
+		}
+
+		time.Sleep(10 * time.Second)
+	}
+}

--- a/internal/systemd/interface.go
+++ b/internal/systemd/interface.go
@@ -45,4 +45,10 @@ type Interface interface {
 
 	// ReconcileSysUpdate reconciles orchestrates a systemd-sysupdate via the systemd-sysupdate@.service unit.
 	ReconcileSysUpdate(ctx context.Context, hv *v1alpha1.Hypervisor) (bool, error)
+
+	// EnableShutdownInhibit enables the shutdown inhibition
+	EnableShutdownInhibit(ctx context.Context, cb func(ctx2 context.Context) error) error
+
+	// DisableShutdownInhibit disables the shutdown inhibition
+	DisableShutdownInhibit() error
 }

--- a/internal/systemd/interface_mock.go
+++ b/internal/systemd/interface_mock.go
@@ -6,7 +6,7 @@ package systemd
 import (
 	"context"
 	"github.com/cobaltcode-dev/kvm-node-agent/api/v1alpha1"
-	"github.com/coreos/go-systemd/v22/dbus"
+	systemd "github.com/coreos/go-systemd/v22/dbus"
 	"sync"
 )
 
@@ -23,13 +23,19 @@ var _ Interface = &InterfaceMock{}
 //			CloseFunc: func()  {
 //				panic("mock out the Close method")
 //			},
-//			GetUnitByNameFunc: func(ctx context.Context, unit string) (dbus.UnitStatus, error) {
+//			DisableShutdownInhibitFunc: func() error {
+//				panic("mock out the DisableShutdownInhibit method")
+//			},
+//			EnableShutdownInhibitFunc: func(ctx context.Context, cb func(ctx2 context.Context) error) error {
+//				panic("mock out the EnableShutdownInhibit method")
+//			},
+//			GetUnitByNameFunc: func(ctx context.Context, unit string) (systemd.UnitStatus, error) {
 //				panic("mock out the GetUnitByName method")
 //			},
 //			IsConnectedFunc: func() bool {
 //				panic("mock out the IsConnected method")
 //			},
-//			ListUnitsByNamesFunc: func(ctx context.Context, units []string) ([]dbus.UnitStatus, error) {
+//			ListUnitsByNamesFunc: func(ctx context.Context, units []string) ([]systemd.UnitStatus, error) {
 //				panic("mock out the ListUnitsByNames method")
 //			},
 //			ReconcileSysUpdateFunc: func(ctx context.Context, hv *v1alpha1.Hypervisor) (bool, error) {
@@ -48,14 +54,20 @@ type InterfaceMock struct {
 	// CloseFunc mocks the Close method.
 	CloseFunc func()
 
+	// DisableShutdownInhibitFunc mocks the DisableShutdownInhibit method.
+	DisableShutdownInhibitFunc func() error
+
+	// EnableShutdownInhibitFunc mocks the EnableShutdownInhibit method.
+	EnableShutdownInhibitFunc func(ctx context.Context, cb func(ctx2 context.Context) error) error
+
 	// GetUnitByNameFunc mocks the GetUnitByName method.
-	GetUnitByNameFunc func(ctx context.Context, unit string) (dbus.UnitStatus, error)
+	GetUnitByNameFunc func(ctx context.Context, unit string) (systemd.UnitStatus, error)
 
 	// IsConnectedFunc mocks the IsConnected method.
 	IsConnectedFunc func() bool
 
 	// ListUnitsByNamesFunc mocks the ListUnitsByNames method.
-	ListUnitsByNamesFunc func(ctx context.Context, units []string) ([]dbus.UnitStatus, error)
+	ListUnitsByNamesFunc func(ctx context.Context, units []string) ([]systemd.UnitStatus, error)
 
 	// ReconcileSysUpdateFunc mocks the ReconcileSysUpdate method.
 	ReconcileSysUpdateFunc func(ctx context.Context, hv *v1alpha1.Hypervisor) (bool, error)
@@ -67,6 +79,16 @@ type InterfaceMock struct {
 	calls struct {
 		// Close holds details about calls to the Close method.
 		Close []struct {
+		}
+		// DisableShutdownInhibit holds details about calls to the DisableShutdownInhibit method.
+		DisableShutdownInhibit []struct {
+		}
+		// EnableShutdownInhibit holds details about calls to the EnableShutdownInhibit method.
+		EnableShutdownInhibit []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Cb is the cb argument value.
+			Cb func(ctx2 context.Context) error
 		}
 		// GetUnitByName holds details about calls to the GetUnitByName method.
 		GetUnitByName []struct {
@@ -100,12 +122,14 @@ type InterfaceMock struct {
 			Unit string
 		}
 	}
-	lockClose              sync.RWMutex
-	lockGetUnitByName      sync.RWMutex
-	lockIsConnected        sync.RWMutex
-	lockListUnitsByNames   sync.RWMutex
-	lockReconcileSysUpdate sync.RWMutex
-	lockStartUnit          sync.RWMutex
+	lockClose                  sync.RWMutex
+	lockDisableShutdownInhibit sync.RWMutex
+	lockEnableShutdownInhibit  sync.RWMutex
+	lockGetUnitByName          sync.RWMutex
+	lockIsConnected            sync.RWMutex
+	lockListUnitsByNames       sync.RWMutex
+	lockReconcileSysUpdate     sync.RWMutex
+	lockStartUnit              sync.RWMutex
 }
 
 // Close calls CloseFunc.
@@ -135,8 +159,71 @@ func (mock *InterfaceMock) CloseCalls() []struct {
 	return calls
 }
 
+// DisableShutdownInhibit calls DisableShutdownInhibitFunc.
+func (mock *InterfaceMock) DisableShutdownInhibit() error {
+	if mock.DisableShutdownInhibitFunc == nil {
+		panic("InterfaceMock.DisableShutdownInhibitFunc: method is nil but Interface.DisableShutdownInhibit was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockDisableShutdownInhibit.Lock()
+	mock.calls.DisableShutdownInhibit = append(mock.calls.DisableShutdownInhibit, callInfo)
+	mock.lockDisableShutdownInhibit.Unlock()
+	return mock.DisableShutdownInhibitFunc()
+}
+
+// DisableShutdownInhibitCalls gets all the calls that were made to DisableShutdownInhibit.
+// Check the length with:
+//
+//	len(mockedInterface.DisableShutdownInhibitCalls())
+func (mock *InterfaceMock) DisableShutdownInhibitCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockDisableShutdownInhibit.RLock()
+	calls = mock.calls.DisableShutdownInhibit
+	mock.lockDisableShutdownInhibit.RUnlock()
+	return calls
+}
+
+// EnableShutdownInhibit calls EnableShutdownInhibitFunc.
+func (mock *InterfaceMock) EnableShutdownInhibit(ctx context.Context, cb func(ctx2 context.Context) error) error {
+	if mock.EnableShutdownInhibitFunc == nil {
+		panic("InterfaceMock.EnableShutdownInhibitFunc: method is nil but Interface.EnableShutdownInhibit was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		Cb  func(ctx2 context.Context) error
+	}{
+		Ctx: ctx,
+		Cb:  cb,
+	}
+	mock.lockEnableShutdownInhibit.Lock()
+	mock.calls.EnableShutdownInhibit = append(mock.calls.EnableShutdownInhibit, callInfo)
+	mock.lockEnableShutdownInhibit.Unlock()
+	return mock.EnableShutdownInhibitFunc(ctx, cb)
+}
+
+// EnableShutdownInhibitCalls gets all the calls that were made to EnableShutdownInhibit.
+// Check the length with:
+//
+//	len(mockedInterface.EnableShutdownInhibitCalls())
+func (mock *InterfaceMock) EnableShutdownInhibitCalls() []struct {
+	Ctx context.Context
+	Cb  func(ctx2 context.Context) error
+} {
+	var calls []struct {
+		Ctx context.Context
+		Cb  func(ctx2 context.Context) error
+	}
+	mock.lockEnableShutdownInhibit.RLock()
+	calls = mock.calls.EnableShutdownInhibit
+	mock.lockEnableShutdownInhibit.RUnlock()
+	return calls
+}
+
 // GetUnitByName calls GetUnitByNameFunc.
-func (mock *InterfaceMock) GetUnitByName(ctx context.Context, unit string) (dbus.UnitStatus, error) {
+func (mock *InterfaceMock) GetUnitByName(ctx context.Context, unit string) (systemd.UnitStatus, error) {
 	if mock.GetUnitByNameFunc == nil {
 		panic("InterfaceMock.GetUnitByNameFunc: method is nil but Interface.GetUnitByName was just called")
 	}
@@ -199,7 +286,7 @@ func (mock *InterfaceMock) IsConnectedCalls() []struct {
 }
 
 // ListUnitsByNames calls ListUnitsByNamesFunc.
-func (mock *InterfaceMock) ListUnitsByNames(ctx context.Context, units []string) ([]dbus.UnitStatus, error) {
+func (mock *InterfaceMock) ListUnitsByNames(ctx context.Context, units []string) ([]systemd.UnitStatus, error) {
 	if mock.ListUnitsByNamesFunc == nil {
 		panic("InterfaceMock.ListUnitsByNamesFunc: method is nil but Interface.ListUnitsByNames was just called")
 	}

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -23,9 +23,10 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"syscall"
 
-	"github.com/coreos/go-systemd/v22/dbus"
-	dbus2 "github.com/godbus/dbus/v5"
+	systemd "github.com/coreos/go-systemd/v22/dbus"
+	"github.com/godbus/dbus/v5"
 	logger "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/cobaltcode-dev/kvm-node-agent/api/v1alpha1"
@@ -39,63 +40,198 @@ const (
 )
 
 type SystemdConn struct {
-	conn *dbus.Conn
+	// go-systemd dbus connection
+	conn *systemd.Conn
+
+	// godbus dbus connection for poweroff inhibition
+	login1conn *dbus.Conn
+
+	// godbus dbus object for poweroff inhibition
+	login1obj dbus.BusObject
+
+	// channel for shutdown signal
+	prepareForShutdownSignal chan *dbus.Signal
+
+	// channel for shutdown goroutine
+	shutdownCh chan bool
+
+	// file descriptor for inhibition
+	fd int
+}
+
+func dialBus() (*dbus.Conn, error) {
+	conn, err := dbus.SystemBusPrivate()
+	if err != nil {
+		return nil, err
+	}
+	methods := []dbus.Auth{
+		dbus.AuthExternal("0"),
+		dbus.AuthExternal(strconv.Itoa(os.Getuid())),
+		dbus.AuthAnonymous(),
+	}
+	if err = conn.Auth(methods); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	if err = conn.Hello(); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return conn, nil
 }
 
 func NewSystemd(ctx context.Context) (*SystemdConn, error) {
-	conn, err := dbus.NewConnection(func() (*dbus2.Conn, error) {
-		conn, err := dbus2.SystemBusPrivate()
-		if err != nil {
-			return nil, err
-		}
-		methods := []dbus2.Auth{
-			dbus2.AuthExternal("0"),
-			dbus2.AuthExternal(strconv.Itoa(os.Getuid())),
-			dbus2.AuthAnonymous(),
-		}
-		if err = conn.Auth(methods); err != nil {
-			_ = conn.Close()
-			return nil, err
-		}
-		if err = conn.Hello(); err != nil {
-			_ = conn.Close()
-			return nil, err
-		}
-		return conn, nil
-	})
+	log := logger.FromContext(ctx)
+
+	log.Info("Connecting to systemd")
+	conn, err := systemd.NewConnection(dialBus)
 	if err != nil {
 		return nil, err
 	}
 
+	// separate connection for systemd inhibition since go-systemd doesn't support it
+	dbusConn, err := dialBus()
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to dbus: %w", err)
+	}
+
 	return &SystemdConn{
-		conn: conn,
+		conn:                     conn,
+		login1conn:               dbusConn,
+		login1obj:                dbusConn.Object("org.freedesktop.login1", "/org/freedesktop/login1"),
+		prepareForShutdownSignal: make(chan *dbus.Signal, 1),
+		shutdownCh:               make(chan bool),
+		fd:                       -1,
 	}, nil
+}
+
+// EnableShutdownInhibit blocks shutdown by using systemd inhibition lock,
+// and registers a shutdown callback
+func (s *SystemdConn) EnableShutdownInhibit(ctx context.Context, cb func(context.Context) error) error {
+	if s.fd != -1 {
+		return fmt.Errorf("shutdown inhibition already enabled")
+	}
+
+	log := logger.Log.WithName("systemd")
+	log.Info("enabling shutdown inhibition")
+
+	// List inhibitors
+	var inhibitors [][]any
+	if err := s.login1obj.CallWithContext(
+		ctx,
+		"org.freedesktop.login1.Manager.ListInhibitors",
+		0,
+	).Store(&inhibitors); err != nil {
+		return fmt.Errorf("failed to list inhibitors: %w", err)
+	}
+	log.Info("existing inhibitors", "inhibitors", inhibitors)
+
+	// create inhibitor
+	if err := s.login1obj.CallWithContext(
+		ctx,
+		"org.freedesktop.login1.Manager.Inhibit",
+		0,
+		"sleep:shutdown",
+		"kvm-node-agent",
+		"Emergency evacuation of host node.",
+		"delay",
+	).Store(&s.fd); err != nil {
+		// ignore error if not running in k8s, so we can debug remotely
+		return fmt.Errorf("error storing file descriptor: %w", err)
+	}
+
+	log.Info("registering shutdown callback")
+	go func() {
+		for {
+			select {
+			case <-s.shutdownCh:
+				log.Info("stopping shutdown callback goroutine")
+				return
+			case signal, ok := <-s.prepareForShutdownSignal:
+				if !ok {
+					log.Info("prepareForShutdownSignal channel closed")
+					return
+				}
+				log.Info("received shutdown signal", "signal", signal)
+
+				// execute the shutdown callback
+				if err := cb(context.Background()); err != nil {
+					log.Error(err, "failed to execute shutdown callback")
+				}
+
+				log.Info("releasing shutdown inhibition")
+				// release the inhibition lock to continue shutdown
+				if err := s.DisableShutdownInhibit(); err != nil {
+					log.Error(err, "failed to release shutdown inhibition")
+				}
+				return
+			}
+		}
+	}()
+
+	// register signal handler
+	if err := s.login1conn.AddMatchSignal(
+		dbus.WithMatchInterface("org.freedesktop.login1.Manager"),
+		dbus.WithMatchObjectPath("/org/freedesktop/login1"),
+		dbus.WithMatchMember("PrepareForShutdown"),
+	); err != nil {
+		return fmt.Errorf("failed to add match signal: %w", err)
+	}
+	s.login1conn.Signal(s.prepareForShutdownSignal)
+
+	return nil
+}
+
+// DisableShutdownInhibit releases the systemd inhibition lock
+func (s *SystemdConn) DisableShutdownInhibit() error {
+	log := logger.Log.WithName("systemd")
+	log.Info("disabling shutdown inhibition")
+
+	if s.fd == -1 {
+		// nothing to do
+		return nil
+	}
+
+	// remove signal handler
+	s.login1conn.RemoveSignal(s.prepareForShutdownSignal)
+
+	// stopping the shutdown callback goroutine
+	s.shutdownCh <- true
+
+	err := syscall.Close(s.fd)
+	if err != nil {
+		return fmt.Errorf("failed to close file descriptor: %w", err)
+	}
+	s.fd = -1
+	return nil
 }
 
 func (s *SystemdConn) Close() {
 	s.conn.Close()
+	_ = s.login1conn.Close()
 }
 
 func (s *SystemdConn) IsConnected() bool {
-	return s.conn.Connected()
+	return s.conn.Connected() && s.login1conn.Connected()
 }
 
-func (s *SystemdConn) ListUnitsByNames(ctx context.Context, units []string) ([]dbus.UnitStatus, error) {
+func (s *SystemdConn) ListUnitsByNames(ctx context.Context, units []string) ([]systemd.UnitStatus, error) {
 	return s.conn.ListUnitsByNamesContext(ctx, units)
 }
 
-func (s *SystemdConn) GetUnitByName(ctx context.Context, unit string) (dbus.UnitStatus, error) {
+func (s *SystemdConn) GetUnitByName(ctx context.Context, unit string) (systemd.UnitStatus, error) {
 	units, err := s.ListUnitsByNames(ctx, []string{unit})
 	if err != nil {
-		return dbus.UnitStatus{}, err
+		return systemd.UnitStatus{}, err
 	}
 	if len(units) == 0 {
-		return dbus.UnitStatus{}, nil
+		return systemd.UnitStatus{}, nil
 	}
 	return units[0], nil
 }
 
 func (s *SystemdConn) StartUnit(ctx context.Context, unit string) (int, error) {
+
 	return s.conn.StartUnitContext(ctx, unit, "replace", nil)
 }
 


### PR DESCRIPTION
Rebooting the hypervisor with active virtual machines will imply an
successful eviction CR bevore the reboot continues, thus helping to
evacuate machines that are restarted due to external events, e.g. human
error, USV failures, automated rollouts (which usally should create
eviction beforehand).

Also:
* Move emulator to it's own folder so it doesn't break regeneration of
  mock interfaces
* add evict CR to service role
* tune default kustomize settings
