### PR TITLE
Run manager in host-network mode

### DIFF
--- a/charts/kvm-node-agent/templates/daemonset.yaml
+++ b/charts/kvm-node-agent/templates/daemonset.yaml
@@ -79,6 +79,7 @@ spec:
           name: pki-libvirt
         - mountPath: /pki/qemu
           name: pki-qemu
+      hostNetwork: true
       initContainers:
       - command:
         - sh

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -52,6 +52,7 @@ spec:
       #             operator: In
       #             values:
       #               - linux
+      hostNetwork: true
       securityContext:
       #  runAsNonRoot: true
         supplementalGroups:


### PR DESCRIPTION
We do not need pod to pod communication, so setting the pod into hostNetwork mode makes it work
even when CNI is not working.
That matches the behaviour of the agents.