### PR TITLE
Tolerate gardener critical components unavailable

### DIFF
--- a/charts/kvm-node-agent/templates/daemonset.yaml
+++ b/charts/kvm-node-agent/templates/daemonset.yaml
@@ -103,6 +103,10 @@ spec:
         8 }}
       serviceAccountName: {{ include "kvm-node-agent.fullname" . }}-controller-manager
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node.gardener.cloud/critical-components-not-ready
+        operator: Exists
       volumes:
       - hostPath:
           path: /run/libvirt/libvirt-sock

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -18,6 +18,12 @@ patches:
         valueFrom:
           fieldRef:
             fieldPath: "{{ .Values.controllerManager.manager.env.nodeLabelFieldPath }}"
+    - op: add
+      path: "/spec/template/spec/tolerations"
+      value:
+      - key: "node.gardener.cloud/critical-components-not-ready"
+        operator: "Exists"
+        effect: "NoSchedule"
   target:
     kind: DaemonSet
     name: controller-manager


### PR DESCRIPTION
Ideally, we make that configurable, but I do not see how. Having a toleration, which doesn't exist doesn't hurt.

This taint will only be removed after we have managed to start a VM, so we need this agent to run with this taint.

We still do not tolerate the following taints:
  node.kubernetes.io/not-ready
  node.kubernetes.io/network-unavailable

So, the node is ready and working, except for our test.