### PR TITLE
Default to no certificates in kvm-node-agent

### DIFF
--- a/api/v1alpha1/hypervisor_types.go
+++ b/api/v1alpha1/hypervisor_types.go
@@ -40,7 +40,7 @@ type HypervisorSpec struct {
 	// EvacuateOnReboot request an evacuation of all instances before reboot.
 	EvacuateOnReboot bool `json:"evacuateOnReboot"`
 
-	// +kubebuilder:default:=true
+	// +kubebuilder:default:=false
 	// Require to issue a certificate from cert-manager for the hypervisor, to be used for
 	// secure communication with the libvirt API.
 	CreateCertManagerCertificate bool `json:"createCertManagerCertificate"`

--- a/charts/kvm-node-agent/crds/hypervisor-crd.yaml
+++ b/charts/kvm-node-agent/crds/hypervisor-crd.yaml
@@ -58,7 +58,7 @@ spec:
             description: HypervisorSpec defines the desired state of Hypervisor
             properties:
               createCertManagerCertificate:
-                default: true
+                default: false
                 description: |-
                   Require to issue a certificate from cert-manager for the hypervisor, to be used for
                   secure communication with the libvirt API.

--- a/config/crd/bases/kvm.cloud.sap_hypervisors.yaml
+++ b/config/crd/bases/kvm.cloud.sap_hypervisors.yaml
@@ -59,7 +59,7 @@ spec:
             description: HypervisorSpec defines the desired state of Hypervisor
             properties:
               createCertManagerCertificate:
-                default: true
+                default: false
                 description: |-
                   Require to issue a certificate from cert-manager for the hypervisor, to be used for
                   secure communication with the libvirt API.


### PR DESCRIPTION
The certificates are now generated in the hypervisor-operator.