### PR TITLE
Disable certificate creation

### DIFF
--- a/charts/kvm-node-agent/templates/daemonset.yaml
+++ b/charts/kvm-node-agent/templates/daemonset.yaml
@@ -35,6 +35,9 @@ spec:
               fieldPath: status.hostIP
         - name: ISSUER_NAME
           value: {{ quote .Values.controllerManager.manager.env.issuerName }}
+        - name: DISABLE_CREATE_CERT_MANAGER_CERTIFICATE
+          value: {{ quote .Values.controllerManager.manager.env.disableCreateCertManagerCertificate
+            }}
         - name: NODE_LABEL
           valueFrom:
             fieldRef:

--- a/charts/kvm-node-agent/values.yaml
+++ b/charts/kvm-node-agent/values.yaml
@@ -14,6 +14,7 @@ controllerManager:
         drop:
         - ALL
     env:
+      disableCreateCertManagerCertificate: "true"
       issuerName: kvm-node-agent-ca-issuer
       pkiPath: /pki
     image:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -83,6 +83,8 @@ spec:
               fieldPath: status.hostIP
         - name: ISSUER_NAME
           value: kvm-node-agent-ca-issuer
+        - name: DISABLE_CREATE_CERT_MANAGER_CERTIFICATE
+          value: "true"
         image: controller:latest
         name: manager
         securityContext:


### PR DESCRIPTION
6e6dcda is not enough since hypervisor objects are created by the node
reconciller which interprets the DISABLE_CREATE_CERT_MANAGER_CERTIFICATE
environment variable
