### PR TITLE
Target all nova.openstack.cloud.sap/virt-driver nodes

### DIFF
--- a/charts/kvm-node-agent/templates/daemonset.yaml
+++ b/charts/kvm-node-agent/templates/daemonset.yaml
@@ -18,6 +18,13 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: nova.openstack.cloud.sap/virt-driver
+                operator: Exists
       containers:
       - args: {{- toYaml .Values.controllerManager.manager.args | nindent 8 }}
         command:
@@ -101,7 +108,6 @@ spec:
         volumeMounts:
         - mountPath: /host
           name: host
-      nodeSelector: {{- toYaml .Values.controllerManager.nodeSelector | nindent 8 }}
       securityContext: {{- toYaml .Values.controllerManager.podSecurityContext | nindent
         8 }}
       serviceAccountName: {{ include "kvm-node-agent.fullname" . }}-controller-manager

--- a/charts/kvm-node-agent/values.yaml
+++ b/charts/kvm-node-agent/values.yaml
@@ -27,8 +27,6 @@ controllerManager:
       requests:
         cpu: 10m
         memory: 64Mi
-  nodeSelector:
-    nova.openstack.cloud.sap/virt-driver: libvirt
   podSecurityContext:
     supplementalGroups:
     - 108

--- a/config/manager/manager_node_selector_patch.yaml
+++ b/config/manager/manager_node_selector_patch.yaml
@@ -6,5 +6,10 @@ metadata:
 spec:
   template:
     spec:
-      nodeSelector:
-        nova.openstack.cloud.sap/virt-driver: libvirt
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: nova.openstack.cloud.sap/virt-driver
+                operator: Exists


### PR DESCRIPTION
The exact value may differ, but currently there is only the libvirt driver for nova anyway, so skip validating the value.

To make it configurable again, best to change helmify. See: https://github.com/arttor/helmify/issues/59