### PR TITLE
Check for /run/libvirt instead of the sockets

### DIFF
--- a/charts/kvm-node-agent/templates/daemonset.yaml
+++ b/charts/kvm-node-agent/templates/daemonset.yaml
@@ -71,11 +71,8 @@ spec:
         securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext
           | nindent 10 }}
         volumeMounts:
-        - mountPath: /run/libvirt/libvirt-sock
-          name: libvirt-sock
-          readOnly: true
-        - mountPath: /run/libvirt/libvirt-admin-sock
-          name: libvirt-admin-sock
+        - mountPath: /run/libvirt
+          name: run-libvirt
           readOnly: true
         - mountPath: /var/run/dbus/system_bus_socket
           name: systemd-sock
@@ -118,13 +115,9 @@ spec:
         operator: Exists
       volumes:
       - hostPath:
-          path: /run/libvirt/libvirt-sock
-          type: Socket
-        name: libvirt-sock
-      - hostPath:
-          path: /run/libvirt/libvirt-admin-sock
-          type: Socket
-        name: libvirt-admin-sock
+          path: /run/libvirt
+          type: Directory
+        name: run-libvirt
       - hostPath:
           path: /run/dbus/system_bus_socket
           type: Socket

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -114,11 +114,8 @@ spec:
             cpu: 10m
             memory: 64Mi
         volumeMounts:
-        - mountPath: /run/libvirt/libvirt-sock
-          name: libvirt-sock
-          readOnly: true
-        - mountPath: /run/libvirt/libvirt-admin-sock
-          name: libvirt-admin-sock
+        - mountPath: /run/libvirt
+          name: run-libvirt
           readOnly: true
         - mountPath: /var/run/dbus/system_bus_socket
           name: systemd-sock
@@ -135,14 +132,10 @@ spec:
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
-      - name: libvirt-sock
+      - name: run-libvirt
         hostPath:
-          path: /run/libvirt/libvirt-sock
-          type: Socket
-      - name: libvirt-admin-sock
-        hostPath:
-          path: /run/libvirt/libvirt-admin-sock
-          type: Socket
+          path: /run/libvirt
+          type: Directory
       - name: systemd-sock
         hostPath:
           path: /run/dbus/system_bus_socket


### PR DESCRIPTION
It looks like the hostpath check for sockets is not reliably working together with socket base activation.
Also, the path specifies the 'old' monolithic socket.

By switching to the whole folder, we leave all that to the application instead of k8s.