### PR TITLE
Fix deprecated ObjectReference usage in cert-manager

### DIFF
--- a/internal/certificates/manage_libvirt.go
+++ b/internal/certificates/manage_libvirt.go
@@ -104,7 +104,7 @@ func EnsureCertificate(ctx context.Context, c client.Client, host string) error 
 			CommonName:  host,
 			DNSNames:    []string{host},
 			IPAddresses: ipAddresses,
-			IssuerRef: v1.ObjectReference{
+			IssuerRef: v1.IssuerReference{
 				Name:  os.Getenv("ISSUER_NAME"),
 				Kind:  cmapi.IssuerKind,
 				Group: "cert-manager.io",


### PR DESCRIPTION
## Summary
- Replace `v1.ObjectReference` with `v1.IssuerReference` in certificate issuer configuration
- Resolves staticcheck SA1019 deprecation warning

## Test plan
- [x] `make check` passes (lint + tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected certificate issuer reference configuration to ensure proper compatibility with certificate management systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->