### PR TITLE
Remove edge tag and force AppVersion for image version

### DIFF
--- a/.github/workflows/container-registry-ghcr.yaml
+++ b/.github/workflows/container-registry-ghcr.yaml
@@ -9,8 +9,8 @@
 name: Container Registry GHCR
 "on":
   push:
-    branches:
-      - main
+    tags:
+      - '*'
   workflow_dispatch: {}
 permissions:
   contents: read
@@ -34,8 +34,6 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            # https://github.com/docker/metadata-action#typeedge
-            type=edge
             # https://github.com/docker/metadata-action#latest-tag
             type=raw,value=latest,enable={{is_default_branch}}
             # https://github.com/docker/metadata-action#typesemver

--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -45,7 +45,6 @@ githubWorkflow:
     tagStrategy:
       - latest
       - semver
-      - edge
       - sha
   pushHelmChartToGhcr:
     path: charts/kvm-node-agent

--- a/charts/kvm-node-agent/Chart.yaml
+++ b/charts/kvm-node-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kvm-node-agent
 description: A Helm chart for Kubernetes
-appVersion: 0.1.0
+appVersion: latest
 version: 0.1.12
 type: application

--- a/charts/kvm-node-agent/templates/daemonset.yaml
+++ b/charts/kvm-node-agent/templates/daemonset.yaml
@@ -51,8 +51,7 @@ spec:
               fieldPath: {{ .Values.controllerManager.manager.env.nodeLabelFieldPath }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
-        image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag
-          | default .Chart.AppVersion }}
+        image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Chart.AppVersion }}
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
We don't use the edge label activly anyway.

Also force usage of AppVersion as image version since it seem to
fallback using latest ever if overriden via helm.