### PR TITLE
Fix goconst linter errors by extracting repeated string literals

### DIFF
--- a/internal/libvirt/libvirt.go
+++ b/internal/libvirt/libvirt.go
@@ -38,6 +38,8 @@ import (
 	"github.com/cobaltcore-dev/kvm-node-agent/internal/libvirt/dominfo"
 )
 
+const supportedYes = "yes"
+
 type LibVirt struct {
 	virt              *libvirt.Libvirt
 	client            client.Client
@@ -372,7 +374,7 @@ func (l *LibVirt) addDomainCapabilities(old v1.Hypervisor) (v1.Hypervisor, error
 	// - <mode name="example3" supported="yes"></mode> becomes "mode/example3"
 	newHv.Status.DomainCapabilities.SupportedCpuModes = []string{}
 	for _, cpuMode := range domCapabilities.CPU.Modes {
-		if cpuMode.Supported != "yes" {
+		if cpuMode.Supported != supportedYes {
 			continue
 		}
 		newHv.Status.DomainCapabilities.SupportedCpuModes = append(
@@ -396,7 +398,7 @@ func (l *LibVirt) addDomainCapabilities(old v1.Hypervisor) (v1.Hypervisor, error
 	// - <video supported="yes"></video> becomes "video".
 	newHv.Status.DomainCapabilities.SupportedDevices = []string{}
 	for _, device := range domCapabilities.Devices.Devices {
-		if device.Supported != "yes" {
+		if device.Supported != supportedYes {
 			continue
 		}
 		newHv.Status.DomainCapabilities.SupportedDevices = append(
@@ -416,7 +418,7 @@ func (l *LibVirt) addDomainCapabilities(old v1.Hypervisor) (v1.Hypervisor, error
 	// Convert the supported features into a flat list.
 	newHv.Status.DomainCapabilities.SupportedFeatures = []string{}
 	for _, feature := range domCapabilities.Features.Features {
-		if feature.Supported == "yes" {
+		if feature.Supported == supportedYes {
 			newHv.Status.DomainCapabilities.SupportedFeatures = append(
 				newHv.Status.DomainCapabilities.SupportedFeatures,
 				feature.XMLName.Local,

--- a/internal/libvirt/utils.go
+++ b/internal/libvirt/utils.go
@@ -24,6 +24,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+const (
+	UnitKiB = "KiB"
+	UnitMiB = "MiB"
+	UnitGiB = "GiB"
+	UnitTiB = "TiB"
+)
+
 type UUID [16]byte
 
 func (uuid UUID) String() string {
@@ -59,13 +66,13 @@ func MemoryToResource(value int64, unit string) (resource.Quantity, error) {
 	var quantity *resource.Quantity
 	// Check the unit
 	switch unit {
-	case "KiB":
+	case UnitKiB:
 		quantity = resource.NewQuantity(value*1024, resource.BinarySI)
-	case "MiB":
+	case UnitMiB:
 		quantity = resource.NewQuantity(value*1024*1024, resource.BinarySI)
-	case "GiB":
+	case UnitGiB:
 		quantity = resource.NewQuantity(value*1024*1024*1024, resource.BinarySI)
-	case "TiB":
+	case UnitTiB:
 		quantity = resource.NewQuantity(value*1024*1024*1024*1024, resource.BinarySI)
 	}
 	if quantity == nil {


### PR DESCRIPTION
Extract repeated string literals into constants to satisfy the goconst linter: "yes" in libvirt.go and memory unit strings in utils.go.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code consistency and maintainability through constant definitions for memory units and standardized comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->